### PR TITLE
Basic support for reading documentation

### DIFF
--- a/Core.Clang/Comment.cs
+++ b/Core.Clang/Comment.cs
@@ -1,0 +1,80 @@
+﻿using System;
+
+namespace Core.Clang
+{
+    public sealed unsafe class Comment
+    {
+        internal CXComment Struct { get; }
+
+        private Comment(CXComment cxComment)
+        {
+            Struct = cxComment;
+        }
+
+        internal static Comment Create(CXComment cxComment)
+        {
+            return new Comment(cxComment);
+        }
+
+        public CommentKind Kind
+        {
+            get
+            {
+                return (CommentKind)NativeMethods.clang_Comment_getKind(Struct);
+            }
+        }
+
+        public int GetNumChildren()
+        {
+            return (int)NativeMethods.clang_Comment_getNumChildren(Struct);
+        }
+
+        public Comment GetChild(int index)
+        {
+            CXComment cxComment = NativeMethods.clang_Comment_getChild(Struct, (uint)index);
+            return Create(cxComment);
+        }
+
+        public string GetText()
+        {
+            if (this.Kind != CommentKind.Text)
+            {
+                throw new InvalidOperationException();
+            }
+
+            CXString cxString = NativeMethods.clang_TextComment_getText(Struct);
+            using (var str = new String(cxString))
+            {
+                return str.ToString();
+            }
+        }
+
+        public string GetParamName()
+        {
+            if (this.Kind != CommentKind.ParamCommand)
+            {
+                throw new InvalidOperationException();
+            }
+
+            CXString cxString = NativeMethods.clang_ParamCommandComment_getParamName(Struct);
+            using (var str = new String(cxString))
+            {
+                return str.ToString();
+            }
+        }
+
+        public string GetCommandName()
+        {
+            if(this.Kind != CommentKind.BlockCommand)
+            {
+                throw new InvalidOperationException();
+            }
+
+            CXString cxString = NativeMethods.clang_BlockCommandComment_getCommandName(Struct);
+            using (var str = new String(cxString))
+            {
+                return str.ToString();
+            }
+        }
+    }
+}

--- a/Core.Clang/CommentKind.cs
+++ b/Core.Clang/CommentKind.cs
@@ -1,0 +1,20 @@
+﻿namespace Core.Clang
+{
+    [EnumMapping(typeof(CXCommentKind), Prefix = "CXComment_")]
+    public enum CommentKind
+    {
+        Null,
+        Text,
+        InlineCommand,
+        HTMLStartTag,
+        HTMLEndTag,
+        Paragraph,
+        BlockCommand,
+        ParamCommand,
+        TParamCommand,
+        VerbatimBlockCommand,
+        VerbatimBlockLine,
+        VerbatimLine,
+        FullComment,
+    }
+}

--- a/Core.Clang/Cursor.cs
+++ b/Core.Clang/Cursor.cs
@@ -1340,6 +1340,14 @@ namespace Core.Clang
             return Create(cxCursor, TranslationUnit);
         }
 
+        public Comment GetParsedComment()
+        {
+            ThrowIfDisposed();
+
+            var cxComment = NativeMethods.clang_Cursor_getParsedComment(Struct);
+            return Comment.Create(cxComment);
+        }
+
         /// <summary>
         /// For a cursor that references something else, return the source range covering that
         /// reference.


### PR DESCRIPTION
This PR adds very basic support for parsing comments/documentation (the `CXComment` struct). It implements what I needed to parse documentation on enums, functions,... 