### PR TITLE
Be explicit about arrays

### DIFF
--- a/Core.Clang/NativeMethods.cs
+++ b/Core.Clang/NativeMethods.cs
@@ -1423,5 +1423,147 @@ namespace Core.Clang
             CXType T,
             IntPtr visitor,
             CXClientDataImpl* client_data);
+
+        [DllImport(dllName)]
+        public static extern CXComment clang_Cursor_getParsedComment(
+            CXCursor C);
+
+        [DllImport(dllName)]
+        public static extern CXCommentKind clang_Comment_getKind(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_Comment_getNumChildren(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXComment clang_Comment_getChild(
+            CXComment Comment,
+            uint ChildIdx);
+
+        [DllImport(dllName)]
+        public static extern uint clang_Comment_isWhitespace(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_InlineContentComment_hasTrailingNewline(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_TextComment_getText(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_InlineCommandComment_getCommandName(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXCommentInlineCommandRenderKind clang_InlineCommandComment_getRenderKind(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_InlineCommandComment_getNumArgs(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_InlineCommandComment_getArgText(
+            CXComment Comment,
+            uint ArgIdx);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_HTMLTagComment_getTagName(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_HTMLStartTagComment_isSelfClosing(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_HTMLStartTag_getNumAttrs(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_HTMLStartTag_getAttrName(
+            CXComment Comment,
+            uint AttrIdx);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_HTMLStartTag_getAttrValue(
+            CXComment Comment,
+            uint AttrIdx);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_BlockCommandComment_getCommandName(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_BlockCommandComment_getNumArgs(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_BlockCommandComment_getArgText(
+            CXComment Comment,
+            uint ArgIdx);
+
+        [DllImport(dllName)]
+        public static extern CXComment clang_BlockCommandComment_getParagraph(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_ParamCommandComment_getParamName(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_ParamCommandComment_isParamIndexValid(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_ParamCommandComment_getParamIndex(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_ParamCommandComment_isDirectionExplicit(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXCommentParamPassDirection clang_ParamCommandComment_getDirection(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_TParamCommandComment_getParamName(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_TParamCommandComment_isParamPositionValid(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_TParamCommandComment_getDepth(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern uint clang_TParamCommandComment_getIndex(
+            CXComment Comment,
+            uint Depth);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_VerbatimBlockLineComment_getText(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_VerbatimLineComment_getText(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_HTMLTagComment_getAsString(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_FullComment_getAsHTML(
+            CXComment Comment);
+
+        [DllImport(dllName)]
+        public static extern CXString clang_FullComment_getAsXML(
+            CXComment Comment);
     }
 }

--- a/Core.Clang/NativeTypes.cs
+++ b/Core.Clang/NativeTypes.cs
@@ -94,20 +94,24 @@ namespace Core.Clang
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct CXFileUniqueID
     {
-        public fixed ulong data[3];
+        public ulong data_0;
+        public ulong data_1;
+        public ulong data_2;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct CXSourceLocation
     {
-        public fixed ulong ptr_data[2];
+        public ulong ptr_data_0;
+        public ulong ptr_data_1;
         public uint int_data;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct CXSourceRange
     {
-        public fixed ulong ptr_data[2];
+        public ulong ptr_data_0;
+        public ulong ptr_data_1;
         public uint begin_int_data;
         public uint end_int_data;
     }
@@ -461,7 +465,9 @@ namespace Core.Clang
     {
         public CXCursorKind kind;
         public int xdata;
-        public fixed ulong data[3];
+        public ulong data_0;
+        public ulong data_1;
+        public ulong data_2;
     }
 
     internal enum CXLinkageKind
@@ -629,7 +635,8 @@ namespace Core.Clang
     internal unsafe struct CXType
     {
         public CXTypeKind kind;
-        public fixed ulong data[2];
+        public ulong data_0;
+        public ulong data_1;
     }
 
     internal enum CXTemplateArgumentKind
@@ -739,7 +746,10 @@ namespace Core.Clang
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct CXToken
     {
-        public fixed uint int_data[4];
+        public uint int_data_0;
+        public uint int_data_1;
+        public uint int_data_2;
+        public uint int_data_3;
         public void* ptr_data;
     }
 
@@ -865,7 +875,8 @@ namespace Core.Clang
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct CXIdxLoc
     {
-        public fixed ulong ptr_data[2];
+        public ulong ptr_data_0;
+        public ulong ptr_data_1;
         public uint int_data;
     }
 
@@ -1115,5 +1126,44 @@ namespace Core.Clang
         CXIndexOpt_IndexImplicitTemplateInstantiations = 0x4,
         CXIndexOpt_SuppressWarnings = 0x8,
         CXIndexOpt_SkipParsedBodiesInSession = 0x10
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct CXComment
+    {
+        public void* ASTNode;
+        public CXTranslationUnitImpl* TranslationUnit;
+    }
+
+    internal enum CXCommentKind
+    {
+        CXComment_Null = 0,
+        CXComment_Text = 1,
+        CXComment_InlineCommand = 2,
+        CXComment_HTMLStartTag = 3,
+        CXComment_HTMLEndTag = 4,
+        CXComment_Paragraph = 5,
+        CXComment_BlockCommand = 6,
+        CXComment_ParamCommand = 7,
+        CXComment_TParamCommand = 8,
+        CXComment_VerbatimBlockCommand = 9,
+        CXComment_VerbatimBlockLine = 10,
+        CXComment_VerbatimLine = 11,
+        CXComment_FullComment = 12
+    }
+
+    internal enum CXCommentInlineCommandRenderKind
+    {
+        CXCommentInlineCommandRenderKind_Normal,
+        CXCommentInlineCommandRenderKind_Bold,
+        CXCommentInlineCommandRenderKind_Monospaced,
+        CXCommentInlineCommandRenderKind_Emphasized
+    }
+
+    internal enum CXCommentParamPassDirection
+    {
+        CXCommentParamPassDirection_In,
+        CXCommentParamPassDirection_Out,
+        CXCommentParamPassDirection_InOut
     }
 }

--- a/Core.Clang/SourceFile.cs
+++ b/Core.Clang/SourceFile.cs
@@ -100,7 +100,7 @@ namespace Core.Clang
             }
 
             var value = id.Value;
-            return value.data[0].GetHashCode() ^ value.data[1].GetHashCode();
+            return value.data_0.GetHashCode() ^ value.data_1.GetHashCode();
         }
 
         /// <summary>

--- a/Core.Clang/SourceLocation.cs
+++ b/Core.Clang/SourceLocation.cs
@@ -157,8 +157,8 @@ namespace Core.Clang
 
             var cxSourceLocation = Struct;
             return
-                cxSourceLocation.ptr_data[0].GetHashCode() ^
-                cxSourceLocation.ptr_data[1].GetHashCode() ^
+                cxSourceLocation.ptr_data_0.GetHashCode() ^
+                cxSourceLocation.ptr_data_1.GetHashCode() ^
                 cxSourceLocation.int_data.GetHashCode();
         }
 

--- a/Core.Clang/SourceRange.cs
+++ b/Core.Clang/SourceRange.cs
@@ -126,8 +126,8 @@ namespace Core.Clang
             ThrowIfDisposed();
 
             var cxSourceRange = Struct;
-            return cxSourceRange.ptr_data[0].GetHashCode() ^
-                cxSourceRange.ptr_data[1].GetHashCode() ^
+            return cxSourceRange.ptr_data_0.GetHashCode() ^
+                cxSourceRange.ptr_data_1.GetHashCode() ^
                 cxSourceRange.begin_int_data.GetHashCode() ^
                 cxSourceRange.end_int_data.GetHashCode();
         }

--- a/Core.Clang/TypeInfo.cs
+++ b/Core.Clang/TypeInfo.cs
@@ -85,7 +85,7 @@ namespace Core.Clang
             ThrowIfDisposed();
 
             var cxType = Struct;
-            return cxType.data[0].GetHashCode() ^ cxType.data[1].GetHashCode();
+            return cxType.data_0.GetHashCode() ^ cxType.data_1.GetHashCode();
         }
 
         /// <summary>

--- a/Playground/Playground.csproj
+++ b/Playground/Playground.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.2" />
+    <PackageReference Include="Native.LibClang" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -11,27 +11,6 @@ namespace Playground
 {
     public class Program
     {
-        private static void CopyClang()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                if (!File.Exists("libclang.dll"))
-                {
-                    var assembly = Assembly.Load(new AssemblyName("Native.LibClang"));
-                    using (var stream = assembly.GetManifestResourceStream("Native.LibClang.LLVM.zip"))
-                    using (var zipArchive = new ZipArchive(stream))
-                    {
-                        var entry = zipArchive.GetEntry("LLVM/bin/libclang.dll");
-                        using (var entryStream = entry.Open())
-                        using (var libraryStream = File.Open("libclang.dll", FileMode.Create, FileAccess.ReadWrite))
-                        {
-                            entryStream.CopyTo(libraryStream);
-                        }
-                    }
-                }
-            }
-        }
-
         private static string GetFilePath([CallerFilePath] string filePath = null)
         {
             return filePath;
@@ -43,8 +22,6 @@ namespace Playground
 
         static Program()
         {
-            CopyClang();
-
             var solutionDirectory = new FileInfo(GetFilePath()).Directory.Parent;
             string path = Environment.GetEnvironmentVariable(nameof(Path));
             path = string.Join(Path.PathSeparator.ToString(),


### PR DESCRIPTION
I had apparently random access violation errors when running code that uses Core.Clang in Release mode.
I was able to reproduce the same behavior by running the Playground project on the `netcoreapp2.0` runtime:
- The program worked in Debug mode
- An AccessViolationException occurred in Release mode.

It turns out that the culprit was the declaration of fixed size arrays. Whereas this worked:
```csharp
internal struct CXCursor
{
    public CXCursorKind kind;
    public int xdata;
    public ulong data_0;
    public ulong data_1;
    public ulong data_2;
}
```

the code would consistently fail when `CXCursor` was declared like this:
```
internal struct CXCursor
{
    public CXCursorKind kind;
    public int xdata;
    public fixed ulong data[3];
}
```

So, this PR updates the code generator to always make "unroll" arrays as member fields.

I also updated the generator code to generate types and methods for the Documentation functionality in Clang.